### PR TITLE
Display Mail adresses alongside name when selecting co authors

### DIFF
--- a/classes/controllers/author_group_controller.php
+++ b/classes/controllers/author_group_controller.php
@@ -117,7 +117,7 @@ class author_group_controller {
      * @param boolean $ingroupsonly
      * @param int $assignment
      * @param $groupsused
-     * @return array:
+     * @return array with [userid] => [Name, email] for every possible co author
      * @throws \coding_exception
      * @throws \dml_exception
      */
@@ -149,11 +149,11 @@ class author_group_controller {
                     if (!$bool || $submission->status != 'submitted') {
                         $authorsubmission = $submissioncontroller->get_author_submission($assignment, $submission->id);
                         if (!($authorsubmission && $authorsubmission->author != $userid)) {
-                            $coauthors[$r->id] = fullname($r);
+                            $coauthors[$r->id] = fullname($r).', '.$r->email;
                         }
                     }
                 } else {
-                    $coauthors[$id] = fullname($r);
+                    $coauthors[$id] = fullname($r).', '.$r->email;
                 }
                 $seen[$id] = '';
             }
@@ -184,11 +184,11 @@ class author_group_controller {
                     if (!$bool || $submission->status != 'submitted') {
                         $authorsubmission = $submissioncontroller->get_author_submission($assignment, $submission->id);
                         if (!($authorsubmission && $authorsubmission->author != $userid)) {
-                            $coauthors[$id] = fullname($r);
+                            $coauthors[$id] = fullname($r).', '.$r->email;
                         }
                     }
                 } else {
-                    $coauthors[$id] = fullname($r);
+                    $coauthors[$id] = fullname($r).', '.$r->email;
                 }
             }
         }


### PR DESCRIPTION
To avoid confusion with multiple names in the same course.